### PR TITLE
Bugfix/fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ version: '2'
 services:
   web:
     image: nginx:alpine
-    label:
+    labels:
       - "devenv.subdomains=my-server"
     networks:
       - devenv

--- a/install-windows.ps1
+++ b/install-windows.ps1
@@ -10,7 +10,7 @@ Move-Item -Force -Path .\*.pem -Destination .\conf/
 Add-DnsClientNrptRule -Namespace "dev.env" -NameServers "127.0.0.1"
 
 # set custom environment variables
-Set-Content -Path .\.env -Value "DEVENV_WEB_PATH=$env:UserProfile/www"
+Set-Content -Path .\.env -Value "DEVENV_WEB_PATH=$env:UserProfile\\www"
 
 # create shared docker network
 docker network create devenv


### PR DESCRIPTION
There are two typos
- the basic-setup in the readme says "label" though it should be "labels". This otherwise causes an error at docker-compose up
- the DEVENV_WEB_PATH accidentally gets created as C:\Users\john.doe/www due to a typo in install-windows.ps1